### PR TITLE
Feber.se new "premium" annoyances

### DIFF
--- a/Frellwits-Swedish-Filter.txt
+++ b/Frellwits-Swedish-Filter.txt
@@ -529,6 +529,8 @@ privataaffarer.se##a[href*="/bit.ly/"]
 /cinnaroll-fusion.min.js^$script,domain=tidningenhembakat.se
 tradera.com##react-adslot
 feber.se##script:inject(set-constant.js, showReklam, false)
+feber.se##.premiumstripe 
+feber.se##[href*="https://login.feber.se/paket/"] 
 feber.se,tjock.se##.art_ad
 feber.se,tjock.se##.art_ad_sign
 digitalfotoforalla.se##.top-banner


### PR DESCRIPTION
This commit removes new feber.se "premium" header bar (ads in disguise) as well as footer advertisement for getting premium. Additional patches might be needed in future.