### PR TITLE
Adding note about Manifest v3

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Various filter lists for [uBlock Origin](https://github.com/gorhill/uBlock) and 
 
 ##
 
-<b>IMPORTANT NOTE FOR CHROMIUM-BROWSER USERS:</b> Our list does not, can not, and will never ever support Manifest v3, due to its laughably short rule limit and the removal of `has`, `has-text`, `csp`, and `##+js`, among others. Issue reports for Manifest v3-based extension versions will not be accepted, and if you do submit one, you would be asked to use an alternate web browser or web browser version instead.
+<b>IMPORTANT NOTE FOR CHROMIUM-BROWSER USERS:</b> Our list does not, can not, and will not support Manifest v3 insofar as it is currently shaped, due to its laughably short rule limit and the removal of `has`, `has-text`, `csp`, and `##+js`, among others. Issue reports for Manifest v3-based extension versions will not be accepted, and if you do submit one, you would be asked to use an alternate web browser or web browser version instead.
 
 ## Available lists
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Various filter lists for [uBlock Origin](https://github.com/gorhill/uBlock) and 
 
 ##
 
-<b>IMPORTANT NOTE FOR CHROMIUM-BROWSER USERS:</b> Our list does not, can not, and will not support Manifest v3 insofar as it is currently shaped, due to its laughably short rule limit and the removal of `has`, `has-text`, `csp`, and `##+js`, among others. Issue reports for Manifest v3-based extension versions will not be accepted, and if you do submit one, you would be asked to use an alternate web browser or web browser version instead.
+<b>IMPORTANT NOTE FOR CHROMIUM-BROWSER USERS:</b> The lists do not, can not, and will not support Chromium's extension Manifest v3 in its current shape and form, due to its exteremly short rule limit, and the possibility of it crippling advanced content blockers which these lists rely on. **If you are using Chrome, Chromium, Opera, Edge, Vivaldi, Brave, or any other browser that's based on Chromium**, then you may have to start preparing to switch your browser to Firefox (or an updated Firfox fork) if you want to continue to use any of these lists within in the coming year(s) (2019-2020).
 
 ## Available lists
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 # Frellwit's filter lists
 Various filter lists for [uBlock Origin](https://github.com/gorhill/uBlock) and [Nano Adblocker](https://github.com/NanoAdblocker/NanoCore).
 
+##
+
+<b>IMPORTANT NOTE FOR CHROMIUM-BROWSER USERS:</b> Our list does not, can not, and will never ever support Manifest v3, due to its laughably short rule limit and the removal of `has`, `has-text`, `csp`, and `##+js`, among others. Issue reports for Manifest v3-based extension versions will not be accepted, and if you do submit one, you would be asked to use an alternate web browser or web browser version instead.
+
 ## Available lists
 
 | List                          | Description                                                             |


### PR DESCRIPTION
So it seems that the Chromium team [has decided to follow through with their war on adblockers](https://9to5google.com/2019/05/29/chrome-ad-blocking-enterprise-manifest-v3/), by having a laughably small current rule limit of 35,000 and by (as far as I can determine) removing most of the more advanced syntaxes that recent adblocker versions can use from October-ish onwards. So tonight I've decided to venture a bit around on the GitHub issue trackers of various lists that are included in adblockers, and get them to publicly take a stance against Manifest v3, in order to educate laymen and to establish *some* kind of pressure on the Chromium team. If they want war, I'll give them just that.

I've turned on the ability for you as a maintainer to edit this pull, should you want to do any changes to the note's text on your own.