### PR TITLE
Removed api.ipify.org, it's a page that show your current IP-address …

### DIFF
--- a/Frellwits-Swedish-Hosts-File.txt
+++ b/Frellwits-Swedish-Hosts-File.txt
@@ -161,7 +161,6 @@
 127.0.0.1 api.fouanalytics.com
 127.0.0.1 api.getlevelten.com
 127.0.0.1 api.innomdc.com
-127.0.0.1 api.ipify.org
 127.0.0.1 api.retargetly.com
 127.0.0.1 api.segment.io
 127.0.0.1 api3847.d41.co

--- a/Swedish/src/main-hosts.txt
+++ b/Swedish/src/main-hosts.txt
@@ -846,7 +846,6 @@
 127.0.0.1 utt.impactcdn.com
 127.0.0.1 scripts.cleverwebserver.com
 127.0.0.1 www.onclickalgo.com
-127.0.0.1 api.ipify.org
 127.0.0.1 prd-collector-platform.ex.co
 127.0.0.1 cdn-eu.clickdimensions.com
 127.0.0.1 twin-iq.kickfire.com


### PR DESCRIPTION
…and not malicious in any way = false positive