### PR TITLE
Fix the rule for ads from LO-Mediehus

### DIFF
--- a/lists/main.txt
+++ b/lists/main.txt
@@ -1787,7 +1787,7 @@ siljannews.se##a[target="_blank"]:upward(2)
 siljannews.se##h3:has-text(/^Annons$/) + div
 /assets/js/ads.js$domain=dagensopinion.se
 arbetet.se,tidningenelektrikern.se,fastighetsfolket.se,handelsnytt.se,ka.se,malarnasfacktidning.se,sekotidningen.se##.Teaser--native, .o-native, [data-controller="ad"], div[id^="consent-"]
-arbetet.se,tidningenelektrikern.se,fastighetsfolket.se,handelsnytt.se,ka.se,malarnasfacktidning.se,sekotidningen.se##.Container:has([data-controller="ad"])
+arbetet.se,tidningenelektrikern.se,fastighetsfolket.se,handelsnytt.se,ka.se,malarnasfacktidning.se,sekotidningen.se##.Container:not(.ContentItem-content):has([data-controller="ad"])
 besoksliv.se##a[href*="sponsrat-innehall"], div[class$="-promotion"]
 vartgoteborg.se##div[class^="Popup"], div[class^="CookieBanner"]
 lysekilsposten.se###archiveAdContainer, .casino-wrapper


### PR DESCRIPTION
The existing rule was a bit over-eager effectively hiding actual articles.